### PR TITLE
Temporarily revert to writing .sst files instead of .ldb.

### DIFF
--- a/db/filename.cc
+++ b/db/filename.cc
@@ -29,14 +29,19 @@ std::string LogFileName(const std::string& name, uint64_t number) {
   return MakeFileName(name, number, "log");
 }
 
+// TableFileName returns the filenames we usually write to, while
+// SSTTableFileName returns the alternative filenames we also try to read from
+// for backward compatibility. For now, swap them around.
+// TODO: when compatibility is no longer necessary, swap them back
+// (TableFileName to use "ldb" and SSTTableFileName to use "sst").
 std::string TableFileName(const std::string& name, uint64_t number) {
   assert(number > 0);
-  return MakeFileName(name, number, "ldb");
+  return MakeFileName(name, number, "sst");
 }
 
 std::string SSTTableFileName(const std::string& name, uint64_t number) {
   assert(number > 0);
-  return MakeFileName(name, number, "sst");
+  return MakeFileName(name, number, "ldb");
 }
 
 std::string DescriptorFileName(const std::string& dbname, uint64_t number) {


### PR DESCRIPTION
See discussion in bitcoin/bitcoin#3529.

This reverts to writing .sst files (the only option in LevelDB 1.13 and below) instead of .ldb files (the default in 1.14 and above). 1.14 and above do read both .sst and .ldb though, so this makes the code backand and forward comaptible with every other version.
