### PR TITLE
Make Hash independent of char signedness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ TESTS = \
 	env_test \
 	filename_test \
 	filter_block_test \
+	hash_test \
 	issue178_test \
 	issue200_test \
 	log_test \
@@ -151,6 +152,9 @@ filename_test: db/filename_test.o $(LIBOBJECTS) $(TESTHARNESS)
 
 filter_block_test: table/filter_block_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(CXX) $(LDFLAGS) table/filter_block_test.o $(LIBOBJECTS) $(TESTHARNESS) -o $@ $(LIBS)
+
+hash_test: util/hash_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(CXX) $(LDFLAGS) util/hash_test.o $(LIBOBJECTS) $(TESTHARNESS) -o $@ $(LIBS)
 
 issue178_test: issues/issue178_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(CXX) $(LDFLAGS) issues/issue178_test.o $(LIBOBJECTS) $(TESTHARNESS) -o $@ $(LIBS)

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -29,7 +29,7 @@ class BloomFilterPolicy : public FilterPolicy {
   }
 
   virtual const char* Name() const {
-    return "leveldb.BuiltinBloomFilter";
+    return "leveldb.BuiltinBloomFilter2";
   }
 
   virtual void CreateFilter(const Slice* keys, int n, std::string* dst) const {

--- a/util/hash.cc
+++ b/util/hash.cc
@@ -34,13 +34,13 @@ uint32_t Hash(const char* data, size_t n, uint32_t seed) {
   // Pick up remaining bytes
   switch (limit - data) {
     case 3:
-      h += data[2] << 16;
+      h += static_cast<unsigned char>(data[2]) << 16;
       FALLTHROUGH_INTENDED;
     case 2:
-      h += data[1] << 8;
+      h += static_cast<unsigned char>(data[1]) << 8;
       FALLTHROUGH_INTENDED;
     case 1:
-      h += data[0];
+      h += static_cast<unsigned char>(data[0]);
       h *= m;
       h ^= (h >> r);
       break;

--- a/util/hash_test.cc
+++ b/util/hash_test.cc
@@ -1,0 +1,44 @@
+// Copyright (c) 2014 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "util/hash.h"
+#include "util/testharness.h"
+
+namespace leveldb {
+
+class HASH { };
+
+TEST(HASH, SignedUnsignedIssue) {
+  const unsigned char data1[1] = {0x62};
+  const unsigned char data2[2] = {0xc3, 0x97};
+  const unsigned char data3[3] = {0xe2, 0x99, 0xa5};
+  const unsigned char data4[4] = {0xe1, 0x80, 0xb9, 0x32};
+  const unsigned char data5[48] = {
+    0x01, 0xc0, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x14, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x04, 0x00,
+    0x00, 0x00, 0x00, 0x14,
+    0x00, 0x00, 0x00, 0x18,
+    0x28, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x02, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+  };
+
+  ASSERT_EQ(Hash(0, 0, 0xbc9f1d34), 0xbc9f1d34);
+  ASSERT_EQ(Hash(reinterpret_cast<const char*>(data1), sizeof(data1), 0xbc9f1d34), 0xef1345c4);
+  ASSERT_EQ(Hash(reinterpret_cast<const char*>(data2), sizeof(data2), 0xbc9f1d34), 0x5b663814);
+  ASSERT_EQ(Hash(reinterpret_cast<const char*>(data3), sizeof(data3), 0xbc9f1d34), 0x323c078f);
+  ASSERT_EQ(Hash(reinterpret_cast<const char*>(data4), sizeof(data4), 0xbc9f1d34), 0xed21633a);
+  ASSERT_EQ(Hash(reinterpret_cast<const char*>(data5), sizeof(data5), 0x12345678), 0xf333dabb);
+}
+
+}  // namespace leveldb
+
+int main(int argc, char** argv) {
+  return leveldb::test::RunAllTests();
+}


### PR DESCRIPTION
Solves an elusive issue with BloomFilterPolicy and interoperability of data files between platforms with signed char (such as x86) and platforms with unsigned char (such as ARM) (see https://github.com/bitcoin/bitcoin/issues/2293).
- Add casts to Hash() to treat chars as unsigned (I think this was  intended).
- Add tests for Hash.
- Change name of algoritm in BloomFilterPolicy::Name to make sure that filters are recomputed; this provides forward and backward compatibility. BloomFilterPolicy has the only use of Hash() that is stored to disk.

I suppose we want to take this upstream first, but those that need this can already apply this patch.
