### PR TITLE
Fixing build on MSVC

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -5,7 +5,9 @@
 #include "leveldb/c.h"
 
 #include <stdlib.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include "leveldb/cache.h"
 #include "leveldb/comparator.h"
 #include "leveldb/db.h"


### PR DESCRIPTION
File unistd.h is only available on unix. It should be excluded from build when compiled with Visual Studio and MSVC toolset.
