### PR TITLE
Ignore env_win.cc on non Windows platforms

### DIFF
--- a/build_detect_platform
+++ b/build_detect_platform
@@ -176,13 +176,14 @@ set -f # temporarily disable globbing so that our patterns aren't expanded
 PRUNE_TEST="-name *test*.cc -prune"
 PRUNE_BENCH="-name *_bench.cc -prune"
 PRUNE_TOOL="-name leveldb_main.cc -prune"
-PORTABLE_FILES=`find $DIRS $PRUNE_TEST -o $PRUNE_BENCH -o $PRUNE_TOOL -o -name '*.cc' -print | sort | sed "s,^$PREFIX/,," | tr "\n" " "`
+PRUNE_PLATFORM_SOURCES="-name env_win.cc -prune"
+PORTABLE_FILES=`find $DIRS $PRUNE_TEST -o $PRUNE_BENCH -o $PRUNE_TOOL -o $PRUNE_PLATFORM_SOURCES -o -name '*.cc' -print | sort | sed "s,^$PREFIX/,," | tr "\n" " "`
 
 set +f # re-enable globbing
 
 # The sources consist of the portable files, plus the platform-specific port
 # file.
-echo "SOURCES=$PORTABLE_FILES $PORT_FILE" >> $OUTPUT
+echo "SOURCES=$PORTABLE_FILES $PORT_FILE $PLATFORM_SOURCES" >> $OUTPUT
 echo "MEMENV_SOURCES=helpers/memenv/memenv.cc" >> $OUTPUT
 
 if [ "$CROSS_COMPILE" = "true" ]; then


### PR DESCRIPTION
Building on non-Windows platforms emits this warning:

```
ar: creating archive libleveldb.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libleveldb.a(env_win.o) has no symbols
```

The `env_win.cc` file should probably be moved to `port/port_win_platform.cc` or something like that, because the upstream logic to list files to compile doesn't work properly with files in `util` directory...
The submitted change tries to workaround it.
